### PR TITLE
secure DOIs

### DIFF
--- a/tumblr_litgen.pl
+++ b/tumblr_litgen.pl
@@ -68,7 +68,7 @@ while ($counter < $numArticles){
 	print $TF $authorList[$counter];
 	print $TF " ($year[$counter])\n";
 	print $TF "<br/>\n";
-	print $TF "<a href=\"dx.doi.org/$doi[$counter]\" ";
+	print $TF "<a href=\"https://doi.org/$doi[$counter]\" ";
 	print $TF "target=\"_new\">\n";
 	print $TF "$title[$counter]\n";
 	print $TF "</a>\n";

--- a/tumblr_out.txt
+++ b/tumblr_out.txt
@@ -4,7 +4,7 @@
 <li>
 Authors, A.
 <br/>
-<a href="dx.doi.org/placeholder" target="_new">
+<a href="https://doi.org/placeholder" target="_new">
 Title.
 </a>
 <br/>
@@ -13,7 +13,7 @@ Journal, Volume, Pages.
 <li>
 Authors, A.
 <br/>
-<a href="dx.doi.org/" target="_new">
+<a href="https://doi.org/" target="_new">
 Title.
 </a>
 <br/>
@@ -22,7 +22,7 @@ Journal, Volume, Pages.
 <li>
 Authors, A.
 <br/>
-<a href="dx.doi.org/" target="_new">
+<a href="https://doi.org/" target="_new">
 Title.
 </a>
 <br/>
@@ -31,7 +31,7 @@ Journal, Volume, Pages.
 <li>
 Authors, A.
 <br/>
-<a href="dx.doi.org/" target="_new">
+<a href="https://doi.org/" target="_new">
 Title.
 </a>
 <br/>
@@ -40,7 +40,7 @@ Journal, Volume, Pages.
 <li>
 Authors, A.
 <br/>
-<a href="dx.doi.org/" target="_new">
+<a href="https://doi.org/" target="_new">
 Title.
 </a>
 <br/>


### PR DESCRIPTION
According to https://www.doi.org/doi_handbook/3_Resolution.html#3.8 dx.doi.org is no longer preferred and since https is supported, I suggest to go the whole way ;-)
